### PR TITLE
Remove unused conditional branch

### DIFF
--- a/db/replica.cc
+++ b/db/replica.cc
@@ -310,8 +310,6 @@ Status Replica<Store>::Commit::SaveChainlet(Builder& to, OpMeta& meta,
                     return Status::OK.comment("non-monotonous frame");
                 }
                 tip_ = from.id();
-            } else {
-                max_;
             }
         } else if (meta.is_check(from)) {
             ok = meta.Check(from);


### PR DESCRIPTION
`max_` is unused and results in the following compile warning:

```
/Users/duane/tmp/ron-cxx/db/replica.cc:314:17: warning: expression result unused
      [-Wunused-value]
                max_;
                ^~~~
/Users/duane/tmp/ron-cxx/db/replica.cc:713:16: note: in instantiation of member function
      'ron::Replica<ron::RocksDBStore<ron::TextFrame> >::Commit::SaveChainlet' requested
      here
template class Replica<RocksDBStore<TextFrame>>;
               ^
1 warning generated.```
