### PR TITLE
Use optional BranchName for branch-scoped commands

### DIFF
--- a/db/main.cc
+++ b/db/main.cc
@@ -300,7 +300,7 @@ Status CommandTest(RonReplica& replica, Args& args) {
 }
 
 constexpr const char* DUMP_USAGE{
-    "dump\n"
+    "dump [BranchName]\n"
     "   dumps the database contents to stdout\n"};
 
 Status CommandDump(RonReplica& replica, Args& args) {
@@ -310,7 +310,16 @@ Status CommandDump(RonReplica& replica, Args& args) {
         if (rdt == ZERO_RAW_FORM) return Status::BADARGS.comment("unknown RDT");
     }*/
     if (!replica.open()) return Status::BAD_STATE.comment("db is not open?");
-    StoreIterator i{replica.GetActiveStore()};
+
+    Uuid branch_id = replica.active_store();
+
+    // Get BranchName, if specified
+    if (!args.empty()) {
+      args.push_back("on");
+      IFOK(ScanOnBranchArg(branch_id, replica, args));
+    }
+
+    StoreIterator i{replica.GetStore(branch_id)};
     IFOK(i.SeekTo(Key{}));
     do {
         cout << i.key().str() << '\t' << i.value().data().str();
@@ -452,14 +461,17 @@ Status CommandNew(RonReplica& replica, Args& args) {
     Uuid name;
     IFOK(ScanAsNameArg(name, SNAKE, replica, args));
 
+    Uuid branch_id;
+    IFOK(ScanOnBranchArg(branch_id, replica, args));
+
     CHECKARG(!args.empty(), NEW_USAGE);
 
     Frame new_obj =
-        OneOp<Frame>(replica.Now(replica.active_store().origin()), rdt);
+        OneOp<Frame>(replica.Now(branch_id.origin()), rdt);
     Builder re;
     Cursor cu{new_obj};
 
-    Commit commit{replica};
+    Commit commit{replica, branch_id};
     IFOK(commit.SaveChain(re, cu));
     Uuid id = commit.tip();  // error for invalids
     if (!name.zero()) {
@@ -571,7 +583,12 @@ Status CommandName(RonReplica& replica, Args& args) {
     IFOK(ScanAsNameArg(name, NUMERIC, replica, args));
     CHECKARG(name.zero(), NAME_USAGE);
 
-    Commit commit{replica};
+    Uuid branch_id;
+    IFOK(ScanOnBranchArg(branch_id, replica, args));
+
+    CHECKARG(!args.empty(), NAME_USAGE);
+
+    Commit commit{replica, branch_id};
     Status ok = commit.WriteName(name, id);
     if (ok) {
         ok = ok.comment("assigned name " + name.str() + " to " + id.str());
@@ -597,10 +614,12 @@ Status CommandNamed(RonReplica& replica, Args& args) {
         what = i->second;
         args.pop_back();
     }
-    Uuid branch;
-    IFOK(ScanOnBranchArg(branch, replica, args));
+    Uuid branch_id;
+    IFOK(ScanOnBranchArg(branch_id, replica, args));
 
-    Commit commit{replica};
+    CHECKARG(!args.empty(), NAMED_USAGE);
+
+    Commit commit{replica, branch_id};
 
     typename RonReplica::Names names;
     IFOK(commit.ReadNames(names));


### PR DESCRIPTION
USAGE document claims that `name`, `named` and `new` commands can accept `[on BranchName]` optional arg; however, code did not reflect this possibility. Added optional arg for:

- "name" command
- "named" command
- also adds BranchName option to object-scoped "new" command

Additionally, this PR adds a new `[BranchName]` optional argument to:

- "dump" command
